### PR TITLE
Add a README for the organisation

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -1,0 +1,24 @@
+# SciPy India
+
+We are a multidisclipinary community and annual conference for users, developers, maintainers, and enthusiasts of the scientific Python stack in India. This GitHub organisation hosts the repositories for the SciPy India community, including the meetups, proposal reviews, annual conference, workshops, archives, and other related projects.
+
+## Quick links
+
+### Looking to propose a talk or workshop?
+
+- [Propose a talk or workshop](https://github.com/scipy-india/proposal-reviewing/issues/new?template=talk-proposal.yaml)
+
+### SciPy India elsewhere
+
+- Visit our [Website](https://scipyindia.org)
+- Join our [Zulip chat](https://scipyindia.zulipchat.com)
+
+### Social media
+
+- [LinkedIn](https://www.linkedin.com/company/scipyindia)
+- [Mastodon](https://fosstodon.org/@scipyindia)
+- [Bluesky](https://bsky.app/profile/scipyindia.bsky.social)
+<!-- TODO: Uncomment when sorted out
+- [Twitter](https://twitter.com/scipyindia)
+- [YouTube](https://www.youtube.com/c/SciPyIndia)
+  -->


### PR DESCRIPTION
- Mentions what SciPy India is
- Adds quick links for proposing a talk, social media handles, and to the website + Zulip chat

Re: a suggestion from @Schefflera-Arboricola in #2 was as follows:

> Also, we can consider putting the report form link in the readme aswell.

On this, I'm not sure if we should link to the report form here directly. We can add a link to the Code of Conduct, which in-turn links to the form (see #2).